### PR TITLE
The use of non-string values as key is enabled.

### DIFF
--- a/lua/mongo-nvim/mongo.lua
+++ b/lua/mongo-nvim/mongo.lua
@@ -22,7 +22,7 @@ function M.list_documents_by_key(dbName, collectionName, key)
     local cursor = collection:find({})
     local documents = {}
     for value in cursor:iterator() do
-        table.insert(documents, value[key])
+        table.insert(documents, tostring(value[key]))
     end
     return documents
 end


### PR DESCRIPTION
I have tried to use `_id` as `list_document_key` and it returns an error, the one described in issue #2. This solves it.